### PR TITLE
Upgrade community_translation from 1.1.1 to 1.1.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -787,16 +787,16 @@
         },
         {
             "name": "concretecms/community_translation",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/addon_community_translation.git",
-                "reference": "65f7d896f752d0de34bd2838dd2ef3d801a75d2b"
+                "reference": "892cb56092327bbebc7ba34819f763b550b4503c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/65f7d896f752d0de34bd2838dd2ef3d801a75d2b",
-                "reference": "65f7d896f752d0de34bd2838dd2ef3d801a75d2b",
+                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/892cb56092327bbebc7ba34819f763b550b4503c",
+                "reference": "892cb56092327bbebc7ba34819f763b550b4503c",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +814,7 @@
                 "issues": "https://github.com/concretecms/addon_community_translation/issues",
                 "source": "https://github.com/concretecms/addon_community_translation"
             },
-            "time": "2022-08-05T09:58:49+00:00"
+            "time": "2022-08-08T17:45:53+00:00"
         },
         {
             "name": "concretecms/concrete_cms_theme",


### PR DESCRIPTION
Whoops... see https://github.com/concretecms/addon_community_translation/compare/1.1.1...1.1.2 and in particular https://github.com/concretecms/addon_community_translation/commit/e9327b0f73fb31cd41004260bfa66275b2945d0b