### PR TITLE
Upgrade community_translation from 1.1.2 to 1.1.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -787,16 +787,16 @@
         },
         {
             "name": "concretecms/community_translation",
-            "version": "1.1.2",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/addon_community_translation.git",
-                "reference": "892cb56092327bbebc7ba34819f763b550b4503c"
+                "reference": "7576592b2da6ceac53f8a985469337cd8c1bedb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/892cb56092327bbebc7ba34819f763b550b4503c",
-                "reference": "892cb56092327bbebc7ba34819f763b550b4503c",
+                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/7576592b2da6ceac53f8a985469337cd8c1bedb7",
+                "reference": "7576592b2da6ceac53f8a985469337cd8c1bedb7",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +814,7 @@
                 "issues": "https://github.com/concretecms/addon_community_translation/issues",
                 "source": "https://github.com/concretecms/addon_community_translation"
             },
-            "time": "2022-08-08T17:45:53+00:00"
+            "time": "2022-08-11T10:37:34+00:00"
         },
         {
             "name": "concretecms/concrete_cms_theme",


### PR DESCRIPTION
The process that imports the strings from Git repositories has two issues:

- at first run it doesn't work (fixed by https://github.com/concretecms/addon_community_translation/commit/193d72ad64c9465f093a98836d8cf181b4478dc2)
- notifications about updated strings aren't send (fixed by https://github.com/concretecms/addon_community_translation/commit/40f91eeac1cdd1ca9a0d4ec37e0051d561e03c75)

Full changelog: https://github.com/concretecms/addon_community_translation/compare/1.1.2...1.1.5 (which includes the two above commits)

Supersedes #51