### PR TITLE
Upgrade community_translation to 1.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "concrete5/community_badges_client": "dev-master",
     "concrete5/core": "dev-develop as 9.x-dev",
     "concrete5/dependency-patches": "^1.6.1",
-    "concretecms/community_translation": "dev-main",
+    "concretecms/community_translation": "^1",
     "concretecms/concrete_cms_theme": "dev-master",
     "mlocati/concrete5-translation-library": "^1.7.1",
     "vlucas/phpdotenv": "^2.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7220e4c4ddf4c0a35110948c3e25f57c",
+    "content-hash": "30916c219398a7e4f0f5ea0bb6b00c5a",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -806,23 +806,22 @@
         },
         {
             "name": "concretecms/community_translation",
-            "version": "dev-main",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/addon_community_translation.git",
-                "reference": "beafb3437764b44ff6b7ffae699381c78e624e67"
+                "reference": "e7f878fa419306452f7b31ebe93ed47be53f9227"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/beafb3437764b44ff6b7ffae699381c78e624e67",
-                "reference": "beafb3437764b44ff6b7ffae699381c78e624e67",
+                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/e7f878fa419306452f7b31ebe93ed47be53f9227",
+                "reference": "e7f878fa419306452f7b31ebe93ed47be53f9227",
                 "shasum": ""
             },
             "require": {
                 "concrete5/core": "^9.0.3a1",
                 "php": "^7.4 || ^8"
             },
-            "default-branch": true,
             "type": "concrete5-package",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -834,7 +833,7 @@
                 "issues": "https://github.com/concretecms/addon_community_translation/issues",
                 "source": "https://github.com/concretecms/addon_community_translation"
             },
-            "time": "2023-01-12T20:47:37+00:00"
+            "time": "2023-01-19T00:53:29+00:00"
         },
         {
             "name": "concretecms/concrete_cms_theme",
@@ -13472,7 +13471,6 @@
     "stability-flags": {
         "concrete5/community_badges_client": 20,
         "concrete5/core": 20,
-        "concretecms/community_translation": 20,
         "concretecms/concrete_cms_theme": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
This new version fixes a bug in CommunityTranslation when using recent PDO/PHP versions - see https://github.com/concretecms/addon_community_translation/pull/63