### PR TITLE
Upgrade community translation to version 1.1.9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -806,16 +806,16 @@
         },
         {
             "name": "concretecms/community_translation",
-            "version": "1.1.9",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/addon_community_translation.git",
-                "reference": "0966ef857f1031aaf811f24180dfabfcc4ca3725"
+                "reference": "dedb051157a4d4ae426594c242ada8a0265be4e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/0966ef857f1031aaf811f24180dfabfcc4ca3725",
-                "reference": "0966ef857f1031aaf811f24180dfabfcc4ca3725",
+                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/dedb051157a4d4ae426594c242ada8a0265be4e2",
+                "reference": "dedb051157a4d4ae426594c242ada8a0265be4e2",
                 "shasum": ""
             },
             "require": {
@@ -833,7 +833,7 @@
                 "issues": "https://github.com/concretecms/addon_community_translation/issues",
                 "source": "https://github.com/concretecms/addon_community_translation"
             },
-            "time": "2023-03-17T16:09:39+00:00"
+            "time": "2023-03-28T07:17:16+00:00"
         },
         {
             "name": "concretecms/concrete_cms_theme",


### PR DESCRIPTION
Changelog: https://github.com/concretecms/addon_community_translation/compare/1.1.9...1.2.0

This essentially changes the attributes that users see when they view/edit their own profile:

| Before | After |
|---|---|
| ![immagine](https://user-images.githubusercontent.com/928116/228160475-0c8b91f0-f710-4d8f-b076-e92c19fab46c.png) | ![immagine](https://user-images.githubusercontent.com/928116/228160065-021f0f36-35d7-462c-857c-15556414f19b.png) |

The main change is the new "Subscribed Packages" attribute: if users want to unsubscribe from all notifications, they simply have to click the new "Unsubscribe all" button (it'll become red: ![immagine](https://user-images.githubusercontent.com/928116/228161024-ed57491e-5b3b-4fee-9ef4-c443c15fb840.png)). and save the profile.