### PR TITLE
Upgrade Community Translation from v1.6.0 to v1.6.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -806,16 +806,16 @@
         },
         {
             "name": "concretecms/community_translation",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/addon_community_translation.git",
-                "reference": "f0319b018ae6a6aa96e1b3b2b901bbb59884f341"
+                "reference": "6cb114f73e14166885e299af146ac07362ee155e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/f0319b018ae6a6aa96e1b3b2b901bbb59884f341",
-                "reference": "f0319b018ae6a6aa96e1b3b2b901bbb59884f341",
+                "url": "https://api.github.com/repos/concretecms/addon_community_translation/zipball/6cb114f73e14166885e299af146ac07362ee155e",
+                "reference": "6cb114f73e14166885e299af146ac07362ee155e",
                 "shasum": ""
             },
             "require": {
@@ -833,7 +833,7 @@
                 "issues": "https://github.com/concretecms/addon_community_translation/issues",
                 "source": "https://github.com/concretecms/addon_community_translation"
             },
-            "time": "2023-11-01T20:02:55+00:00"
+            "time": "2023-11-03T11:11:06+00:00"
         },
         {
             "name": "concretecms/concrete_cms_theme",


### PR DESCRIPTION
[Changelog](https://github.com/concretecms/addon_community_translation/compare/1.6.0...1.6.1)